### PR TITLE
Add default values for optional arguments

### DIFF
--- a/wordpress-xmlrpc-autop.php
+++ b/wordpress-xmlrpc-autop.php
@@ -8,7 +8,7 @@
 
 add_filter( 'xmlrpc_prepare_post', 'cpdm_xmlrpc_methods' );
 
-function cpdm_xmlrpc_methods( $post, $orig_post, $fields )
+function cpdm_xmlrpc_methods( $post, $orig_post = null , $fields = null )
 {
 	if (isset($post['post_content'])) {
 		$post['post_content'] = wpautop($post['post_content']);


### PR DESCRIPTION
After a PHP and/or WordPress update I discovered that the XML-RPC API was returning a 500. Turns out PHP wasn't happy about the function being called with only one argument.

Anyway, thanks a bunch for this plugin!